### PR TITLE
Redesign of messages endpoint API.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,8 +10,6 @@ config.messages = {};
 config.messages.newMessages = [];
 config.messages.endpoints = {};
 config.messages.endpoints.messages = '/messages';
-config.messages.endpoints.messagesSearch = '/messages-search';
-config.messages.endpoints.messagesBatch = '/messages-batch';
 
 // load validation schemas
 config.validation.schema.paths.push(path.join(__dirname, '..', 'schemas'));

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -337,14 +337,8 @@ function validateMessages(m) {
 
 // Retrive ALL messages associated with the recipient
 function get(actor, query, recipient, callback) {
-  var limit = 0;
-  var offset = 0;
-  if(query.limit) {
-    limit = query.limit;
-  }
-  if(query.offset) {
-    offset = query.offset;
-  }
+  var limit = query.limit || 0;
+  var offset = query.offset || 0;
   async.auto({
     checkPermissions: function(callback) {
       brPermission.checkPermission(

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -159,41 +159,10 @@ api.store = function(messages, callback) {
 // add routes
 bedrock.events.on('bedrock-express.configure.routes', function(app) {
   // FIXME: what is the permissions model for this?
-  app.get(
-    config.messages.endpoints.messages + '/:id', rest.when.prefers.ld,
-    ensureAuthenticated, function(req, res, next) {
-      getId(
-        req.user.identity, req.params.id, {recipient: req.user.identity.id},
-        function(err, results) {
-        if(err) {
-          return next(err);
-        }
-        res.json(results);
-      });
-    });
 
-  // Update endpoint, single
-  app.post(
-    config.messages.endpoints.messages + '/:id', rest.when.prefers.ld,
-    ensureAuthenticated, function(req, res, next) {
-      if(req.body.message !== req.params.id) {
-        return next(new BedrockError(
-          'Message ID mismatch.', 'MessageIdMismatch',
-          {httpStatusCode: 409, 'public': true}));
-      }
-      updateMessage(
-        req.user.identity, req.body, {recipient: req.user.identity.id},
-        function(err, results) {
-        if(err) {
-          return next(err);
-        }
-        res.json(results);
-      });
-    });
-
-  // Update endpoint, batch
-  app.post(
-    config.messages.endpoints.messagesBatch, rest.when.prefers.ld,
+  // Update endpoint
+  app.patch(
+    config.messages.endpoints.messages, rest.when.prefers.ld,
     ensureAuthenticated, function(req, res, next) {
       batchUpdate(
         req.user.identity, req.body, {recipient: req.user.identity.id},
@@ -205,26 +174,21 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
       });
     });
 
-  // Delete endpoint, single
+  // Delete endpoint
   app.delete(
-    config.messages.endpoints.messages + '/:id', rest.when.prefers.ld,
+    config.messages.endpoints.messages, rest.when.prefers.ld,
     ensureAuthenticated, function(req, res, next) {
-      deleteMessage(
-        req.user.identity, req.params.id, {recipient: req.user.identity.id},
-        function(err, results) {
-        if(err) {
-          return next(err);
-        }
-        res.json(results);
+      if(!req.query.id) {
+        return next(new BedrockError(
+          'InvalidRequest.', 'InvalidRequest',
+          {httpStatusCode: 404, 'public': true}));
+      }
+      var messages = [];
+      req.query.id.split(',').forEach(function(id) {
+        messages.push(id);
       });
-    });
-
-  // Delete endpoint, batch
-  app.delete(
-    config.messages.endpoints.messagesBatch, rest.when.prefers.ld,
-    ensureAuthenticated, function(req, res, next) {
       batchDelete(
-        req.user.identity, req.body, {recipient: req.user.identity.id},
+        req.user.identity, messages, {recipient: req.user.identity.id},
         function(err, results) {
         if(err) {
           return next(err);
@@ -233,45 +197,59 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
       });
     });
 
-  // retrieve messages for the identity authenticated by brPassport
-  app.post(config.messages.endpoints.messagesSearch, ensureAuthenticated,
+  // Get endpoint
+  app.get(config.messages.endpoints.messages, ensureAuthenticated,
     function(req, res, next) {
-      get(req.user.identity, req.user.identity.id, function(err, results) {
-        if(err) {
-          return next(err);
-        }
-        res.json(results);
-      });
-    });
-
-  // return ALL messages for a recipient, this will be used by
-  // bedrock-message-client
-  // FIXME: this endpoint is intended for users/admins that are not the
-  // recipient to query for messages
-  // TODO: we might want to create a seperate endpoint that only returns
-  // message header information, the main use case for function is to populate
-  // a list of messages (subject/sender/date), so returning the whole message is
-  // unneccessary
-  app.post(config.messages.endpoints.messagesSearch + '/:recipient',
-    ensureAuthenticated, function(req, res, next) {
-      get(req.user.identity, req.params.recipient, function(err, results) {
-        if(err) {
-          return next(err);
-        }
-        res.json(results);
-      });
-    });
-
-  // return new messages, this endpoint will not return the same results twice
-  app.post(
-    config.messages.endpoints.messagesSearch + '/:recipient/new',
-    ensureAuthenticated, function(req, res, next) {
-      getNew(req.user.identity, req.params.recipient, function(err, results) {
-        if(err) {
-          return next(err);
-        }
-        res.json(results);
-      });
+      // Retrieve single message
+      if(req.query.id) {
+        getId(
+          req.user.identity, req.query.id, {recipient: req.user.identity.id},
+          function(err, results) {
+          if(err) {
+            return next(err);
+          }
+          res.json(results);
+        });
+        return;
+      }
+      // Retrieve new messages for recipient
+      if(req.query.state === 'new' && req.query.recipient &&
+        !req.query.limit && !req.query.offset) {
+        getNew(req.user.identity, req.query.recipient, function(err, results) {
+          if(err) {
+            return next(err);
+          }
+          res.json(results);
+        });
+        return;
+      }
+      // Retrieve messages for recipient
+      if(req.query.recipient) {
+        get(req.user.identity, req.query, req.query.recipient,
+          function(err, results) {
+          if(err) {
+            return next(err);
+          }
+          res.json(results);
+        });
+        return;
+      }
+      // Retrieve messages for currently authenticated user
+      if(!req.query.recipient && !req.query.id) {
+        get(
+          req.user.identity, req.query, req.user.identity.id,
+          function(err, results) {
+          if(err) {
+            return next(err);
+          }
+          res.json(results);
+        });
+        return;
+      }
+      // Invalid query paramaters sent
+      return next(new BedrockError(
+          'InvalidRequest.', 'InvalidRequest',
+          {httpStatusCode: 404, 'public': true}));
     });
 });
 
@@ -283,8 +261,8 @@ api.getMessages = function(actor, messages, options, callback) {
 api._getNew = function(actor, recipient, callback) {
   getNew(actor, recipient, callback);
 };
-api._get = function(actor, recipient, callback) {
-  get(actor, recipient, callback);
+api._get = function(actor, query, recipient, callback) {
+  get(actor, query, recipient, callback);
 };
 api._getId = function(actor, id, options, callback) {
   getId(actor, id, options, callback);
@@ -298,8 +276,8 @@ api._batchUpdate = function(actor, request, options, callback) {
 api._deleteMessage = function(actor, id, options, callback) {
   deleteMessage(actor, id, options, callback);
 };
-api._batchDelete = function(actor, request, options, callback) {
-  batchDelete(actor, request, options, callback);
+api._batchDelete = function(actor, messages, options, callback) {
+  batchDelete(actor, messages, options, callback);
 };
 
 // sort messages into two arrays, valid and invalid
@@ -332,7 +310,15 @@ function validateMessages(m) {
 }
 
 // Retrive ALL messages associated with the recipient
-function get(actor, recipient, callback) {
+function get(actor, query, recipient, callback) {
+  var limit = 0;
+  var offset = 0;
+  if(query.limit) {
+    limit = query.limit;
+  }
+  if(query.offset) {
+    offset = query.offset;
+  }
   async.auto({
     checkPermissions: function(callback) {
       brPermission.checkPermission(
@@ -355,7 +341,11 @@ function get(actor, recipient, callback) {
         'value.type': true,
         'value.content': true
       };
-      store.find(q, projection)
+      var options = {
+        limit: limit,
+        skip: offset
+      };
+      store.find(q, projection, options)
         .toArray(function(err, result) {
           if(err) {
             return callback(err);
@@ -510,19 +500,17 @@ function updateMessage(actor, request, options, callback) {
 }
 
 function batchUpdate(actor, request, options, callback) {
-  if(request.operation !== 'archive') {
-    // No suitable operation found, return error
-    return callback(new BedrockError(
-      'No suitable update operation', 'MessageUpdateBatch', {
+  var messages = [];
+  for(var operation in request) {
+    // TODO: Support multiple types of operations
+    // (right now only 'archive' is supported).
+    if(request[operation].op !== 'archive' || !request[operation].id) {
+      return callback(new BedrockError(
+      'Invalid patch operation', 'MessageUpdate', {
         httpStatusCode: 400,
         public: true}));
-  }
-  if(!request.messages) {
-    // No messages supplied, return error
-    return callback(new BedrockError(
-      'No messages supplied', 'MessageUpdateBatch', {
-        httpStatusCode: 400,
-        public: true}));
+    }
+    messages.push(request[operation].id);
   }
   async.auto({
     checkPermissions: function(callback) {
@@ -531,7 +519,7 @@ function batchUpdate(actor, request, options, callback) {
         callback);
     },
     batchOperation: ['checkPermissions', function(callback) {
-      var ids = request.messages.map(function(message) {
+      var ids = messages.map(function(message) {
         return database.hash(message);
       });
       var q = {
@@ -558,7 +546,7 @@ function batchUpdate(actor, request, options, callback) {
       });
     }],
     checkResults: ['batchOperation', function(callback, results) {
-      if(results.batchOperation.result.nModified === request.messages.length) {
+      if(results.batchOperation.result.nModified === messages.length) {
         return callback(null, results.batchOperation);
       }
       // FIXME: should error reporting here be more sophisticated
@@ -608,8 +596,8 @@ function deleteMessage(actor, id, options, callback) {
   });
 }
 
-function batchDelete(actor, request, options, callback) {
-  if(!request.messages) {
+function batchDelete(actor, messages, options, callback) {
+  if(!messages) {
     return callback(
       new BedrockError('No messages supplied', 'MessageDeleteBatch', {
       httpStatusCode: 400,
@@ -623,7 +611,7 @@ function batchDelete(actor, request, options, callback) {
         callback);
     },
     deleteOperation: ['checkPermissions', function(callback) {
-      var ids = request.messages.map(function(message) {
+      var ids = messages.map(function(message) {
         return database.hash(message);
       });
       var q = {
@@ -643,7 +631,7 @@ function batchDelete(actor, request, options, callback) {
       });
     }],
     checkResults: ['deleteOperation', function(callback, results) {
-      if(results.deleteOperation.result.n === request.messages.length) {
+      if(results.deleteOperation.result.n === messages.length) {
         return callback(null, results.deleteOperation);
       }
       // FIXME: should error reporting here be more sophisticated

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -164,9 +164,39 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
   app.patch(
     config.messages.endpoints.messages, rest.when.prefers.ld,
     ensureAuthenticated, function(req, res, next) {
-      batchUpdate(
-        req.user.identity, req.body, {recipient: req.user.identity.id},
-        function(err, results) {
+      // Seperate all "delete" operations from other operations
+      var operations = req.body;
+      var deleteOperations = operations.filter(function(operation) {
+        return operation.op === 'delete';
+      });
+      var updateOperations = operations.filter(function(operation) {
+        return operation.op !== 'delete';
+      });
+      async.auto({
+        delete: function(callback) {
+          if(!deleteOperations.length === 0) {
+            return callback();
+          }
+          var messages = deleteOperations.map(function(operation) {
+            return operation.id;
+          });
+          batchDelete(
+            req.user.identity,
+            messages,
+            {recipient: req.user.identity.id},
+            callback);
+        },
+        update: function(callback) {
+          if(updateOperations.length === 0) {
+            return callback();
+          }
+          batchUpdate(
+            req.user.identity,
+            updateOperations,
+            {recipient: req.user.identity.id},
+            callback);
+        }
+      }, function(err, results) {
         if(err) {
           return next(err);
         }
@@ -183,12 +213,8 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
           'InvalidRequest.', 'InvalidRequest',
           {httpStatusCode: 404, 'public': true}));
       }
-      var messages = [];
-      req.query.id.split(',').forEach(function(id) {
-        messages.push(id);
-      });
-      batchDelete(
-        req.user.identity, messages, {recipient: req.user.identity.id},
+      deleteMessage(
+        req.user.identity, req.query.id, {recipient: req.user.identity.id},
         function(err, results) {
         if(err) {
           return next(err);
@@ -324,6 +350,22 @@ function get(actor, query, recipient, callback) {
       brPermission.checkPermission(
         actor, PERMISSIONS.MESSAGE_ACCESS, {resource: recipient}, callback);
     },
+    totalCount: ['checkPermissions', function(callback, results) {
+      var q = {
+        recipient: database.hash(recipient)
+      };
+      store.count(q, callback);
+    }],
+    queryCount: ['checkPermissions', function(callback, results) {
+      var q = {
+        recipient: database.hash(recipient)
+      };
+      var options = {
+        limit: limit,
+        skip: offset
+      };
+      store.count(q, options, callback);
+    }],
     find: ['checkPermissions', function(callback, results) {
       var q = {
         recipient: database.hash(recipient)


### PR DESCRIPTION
We only have one endpoint now instead of individual search and batch endpoints like before -- looks like this:
GET /messages  - Get all messages for a user
Filters
?recipient=uuid - retrieves messages for a specific user, default is to recieve for authenticated user
?id=uuid - retrieves specific message
?limit=int
?offset=int
?state=new - not compatible with other filters
PATCH /messages - Update collection of messages
[
    { "op": "archive", "id": "messageUuid1"},
    { "op": "archive", "id": "messageUuid2" },
    { "op": "archive", "id": "messageUuid3"}
]
DELETE /messages?id=id1,id2,id3 - deletes specific messages. must supply paramaters (doesn't support deletion of all messages by just hitting /messages, think that is a good thing?)
